### PR TITLE
add option to append hash instead of replace it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-smart-asset",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ Checkout [tests](test) for examples.
     * `basePath` - path or array of paths to search assets (relative to `from`, or absolute)
     * `assetsPath` - directory to copy assets (relative to `to` or absolute)
     * `useHash` - use filehash(xxhash) for naming
+    * `prependName` - use filename__hash as filename (assuming useHash is also true)
     * `hashOptions` - options for hash function
 * `custom {Function}`
     * `multi` - processing with other options
@@ -264,6 +265,12 @@ destination
 _(default: `false`)_
 
 If set to `true` the copy method is going to rename the path of the files by a hash name
+
+#### `prependName`
+
+_(default: `false`)_
+
+If set to `true` and `useHash` is also true, the copy method appends the hash to the original file name instead of replacing it
 
 #### `hashOptions`
 

--- a/src/lib/decl-processor.js
+++ b/src/lib/decl-processor.js
@@ -226,5 +226,6 @@ export const declProcessor = (from, to, options, result, decl) => {
  * @property {Number} [maxSize] - max file size in kbytes for inline mode
  * @property {String} [fallback] - fallback mode if file exceeds maxSize
  * @property {Boolean} [useHash] - use file hash instead filename
+ * @property {Boolean} [prependName] - if useHash is true, appends the hash to the filename instead of replacing it
  * @property {HashOptions} [hashOptions] - params for generating hash name
  */

--- a/src/type/copy.js
+++ b/src/type/copy.js
@@ -38,7 +38,13 @@ export default async function processCopy(asset, dir, options, decl, warn, resul
 
   addDependency(file.path)
 
-  const assetRelativePath = options.useHash ? await getHashName(file, options.hashOptions) : asset.relativePath
+  let assetRelativePath = options.useHash ? await getHashName(file, options.hashOptions) : asset.relativePath
+  if(options.useHash && options.prependName){
+    let pathObj = path.parse(assetRelativePath), fileName = path.parse(asset.relativePath).name;
+    pathObj.name = fileName + '_' + pathObj.name;
+    delete pathObj.base; //otherwise it would override name
+    assetRelativePath = path.format(pathObj);
+  }
 
   const targetDir = getTargetDir(dir)
   const newAssetBaseDir = getAssetsPath(targetDir, options.assetsPath)

--- a/src/type/copy.test.js
+++ b/src/type/copy.test.js
@@ -64,6 +64,7 @@ describe("copy when inline fallback", () => {
 
 function testCopy(opts, postcssOpts) {
   const optsWithHash = Object.assign({}, opts, { useHash: true })
+  const optsWithHashAppend = Object.assign({}, opts, { useHash: true, prependName: true })
   const assetsPath = opts.assetsPath ? `${opts.assetsPath}\/` : ""
   const patterns = {
     copyPixelPng: new RegExp(`"./${assetsPath}imported\/pixel\.png"`),
@@ -72,7 +73,9 @@ function testCopy(opts, postcssOpts) {
     copyParamsPixelPngParam: new RegExp(`"./${assetsPath}imported\/pixel\\.png\\?foo=bar"`),
     copyParamsPixelGif: new RegExp(`"./${assetsPath}pixel\\.gif\\#el"`),
     copyHashPixel8: new RegExp(`"./${assetsPath}dDcMwK\\.png"`),
-    copyHashParamsPixel8: new RegExp(`"./${assetsPath}dDcMwK\\.png\\?v=1\\.1\\#iefix"`)
+    copyHashParamsPixel8: new RegExp(`"./${assetsPath}dDcMwK\\.png\\?v=1\\.1\\#iefix"`),
+    copyHashAppendPixel8: new RegExp(`"./${assetsPath}pixel_dDcMwK\\.png"`),
+    copyHashAppendParamsPixel8: new RegExp(`"./${assetsPath}pixel_dDcMwK\\.png\\?v=1\\.1\\#iefix"`)
   }
   const matchAll = (css, patternsKeys) =>
     expect(patternsKeys.every((pat) => css.match(patterns[pat]))).toBeTruthy()
@@ -99,6 +102,18 @@ function testCopy(opts, postcssOpts) {
     test("rebase the url using a hash name keeping parameters", () => {
       return processedCss("copy-hash-parameters", optsWithHash, postcssOpts).then((css) => {
         matchAll(css, [ "copyHashParamsPixel8" ])
+      })
+    })
+
+    test("rebase the url appending a hash to the name", () => {
+      return processedCss("copy-hash", optsWithHashAppend, postcssOpts).then((css) => {
+        matchAll(css, [ "copyHashAppendPixel8" ])
+      })
+    })
+
+    test("rebase the url using appending a hash to the name name keeping parameters", () => {
+      return processedCss("copy-hash-parameters", optsWithHashAppend, postcssOpts).then((css) => {
+        matchAll(css, [ "copyHashAppendParamsPixel8" ])
       })
     })
   })


### PR DESCRIPTION
this is a requirement for a PR i am about to open in your rollup rebase plugin. I think it'd be easier to work with filenames that have the hash appended to them rather than replacing them. So instead of `abc123.png`, it'll be `blah_abc123.png`

I left it behind an option to not force the behavior on everyone, but I think it'd be nicer to use overall.